### PR TITLE
Add jobs to integrate terraform-provider-openstack with generic clouds

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -34,3 +34,9 @@
     recheck-fwaas:
       jobs:
         - terraform-provider-openstack-acceptance-test-fwaas
+    check-generic-cloud:
+      jobs:
+        - terraform-provider-openstack-acceptance-test-telefonica
+        - terraform-provider-openstack-acceptance-test-huaweicloud
+        - terraform-provider-openstack-acceptance-test-orange
+        - terraform-provider-openstack-acceptance-test-opentelekomcloud


### PR DESCRIPTION
Add jobs to integrate terraform-provider-openstack with
public clouds: telefonica, orange, opentelekomcloud and huaweicloud.

Related-Bug: theopenlab/openlab#125